### PR TITLE
DocumentsApi Insert / Update: url param is optional

### DIFF
--- a/docs/DocumentsApi.md
+++ b/docs/DocumentsApi.md
@@ -314,16 +314,15 @@ record_type = "record_type_example" # String | Entity type
 
 title = "title_example" # String | Document title
 
-url = "url_example" # String | Document url
-
 opts = { 
-  file: File.new("/path/to/file.txt"), # File | File to upload
+  url: "//path/to/file", # String | Url of file to attach
+  file: File.open("/path/to/file.txt"), # File | File to upload
   private_flag: true, # BOOLEAN | Indicates if document is private
   read_only_flag: true # BOOLEAN | Indicates if document is readonly
 }
 
 begin
-  result = api_instance.system_documents_id_post(id, record_id, record_type, title, url, opts)
+  result = api_instance.system_documents_id_post(id, record_id, record_type, title, opts)
   p result
 rescue Connectwise::ApiError => e
   puts "Exception when calling DocumentsApi->system_documents_id_post: #{e}"
@@ -338,8 +337,8 @@ Name | Type | Description  | Notes
  **record_id** | **Integer**| Entity id | 
  **record_type** | **String**| Entity type | 
  **title** | **String**| Document title | 
- **url** | **String**| Document url | 
- **file** | **File**| File to upload | [optional] 
+ **url** | **String**| Document url | [optional if file present]
+ **file** | **File**| File to upload | [optional if url present] 
  **private_flag** | **BOOLEAN**| Indicates if document is private | [optional] 
  **read_only_flag** | **BOOLEAN**| Indicates if document is readonly | [optional] 
 
@@ -384,16 +383,15 @@ record_type = "record_type_example" # String | Entity type
 
 title = "title_example" # String | Document title
 
-url = "url_example" # String | Document url
-
 opts = { 
-  file: File.new("/path/to/file.txt"), # File | File to upload
+  url: "//path/to/file", # String | Document url
+  file: File.open("/path/to/file.txt"), # File | File to upload
   private_flag: true, # BOOLEAN | Indicates if document is private
   read_only_flag: true # BOOLEAN | Indicates if document is readonly
 }
 
 begin
-  result = api_instance.system_documents_post(record_id, record_type, title, url, opts)
+  result = api_instance.system_documents_post(record_id, record_type, title, opts)
   p result
 rescue Connectwise::ApiError => e
   puts "Exception when calling DocumentsApi->system_documents_post: #{e}"

--- a/lib/connectwise-ruby-sdk/api/documents_api.rb
+++ b/lib/connectwise-ruby-sdk/api/documents_api.rb
@@ -31,22 +31,22 @@ module Connectwise
       @api_client = api_client
     end
 
-    # 
+    #
     # Get Documents Info Count
     # @param [Hash] opts the optional parameters
-    # @option opts [String] :record_type 
-    # @option opts [Integer] :record_id 
+    # @option opts [String] :record_type
+    # @option opts [Integer] :record_id
     # @return [Count]
     def system_documents_count_get(opts = {})
       data, _status_code, _headers = system_documents_count_get_with_http_info(opts)
       return data
     end
 
-    # 
+    #
     # Get Documents Info Count
     # @param [Hash] opts the optional parameters
-    # @option opts [String] :record_type 
-    # @option opts [Integer] :record_id 
+    # @option opts [String] :record_type
+    # @option opts [Integer] :record_id
     # @return [Array<(Count, Fixnum, Hash)>] Count data, response status code and response headers
     def system_documents_count_get_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -93,26 +93,26 @@ module Connectwise
       return data, status_code, headers
     end
 
-    # 
+    #
     # Get Documents Info
     # @param [Hash] opts the optional parameters
-    # @option opts [String] :record_type 
-    # @option opts [Integer] :record_id 
-    # @option opts [Integer] :page 
-    # @option opts [Integer] :page_size 
+    # @option opts [String] :record_type
+    # @option opts [Integer] :record_id
+    # @option opts [Integer] :page
+    # @option opts [Integer] :page_size
     # @return [Array<DocumentInfo>]
     def system_documents_get(opts = {})
       data, _status_code, _headers = system_documents_get_with_http_info(opts)
       return data
     end
 
-    # 
+    #
     # Get Documents Info
     # @param [Hash] opts the optional parameters
-    # @option opts [String] :record_type 
-    # @option opts [Integer] :record_id 
-    # @option opts [Integer] :page 
-    # @option opts [Integer] :page_size 
+    # @option opts [String] :record_type
+    # @option opts [Integer] :record_id
+    # @option opts [Integer] :page
+    # @option opts [Integer] :page_size
     # @return [Array<(Array<DocumentInfo>, Fixnum, Hash)>] Array<DocumentInfo> data, response status code and response headers
     def system_documents_get_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -161,9 +161,9 @@ module Connectwise
       return data, status_code, headers
     end
 
-    # 
+    #
     # Delete Document Info By Id
-    # @param id 
+    # @param id
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def system_documents_id_delete(id, opts = {})
@@ -171,9 +171,9 @@ module Connectwise
       return nil
     end
 
-    # 
+    #
     # Delete Document Info By Id
-    # @param id 
+    # @param id
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def system_documents_id_delete_with_http_info(id, opts = {})
@@ -217,22 +217,22 @@ module Connectwise
       return data, status_code, headers
     end
 
-    # 
+    #
     # Download Document
-    # @param id 
+    # @param id
     # @param [Hash] opts the optional parameters
-    # @option opts [String] :last_modified 
+    # @option opts [String] :last_modified
     # @return [nil]
     def system_documents_id_download_get(id, opts = {})
       system_documents_id_download_get_with_http_info(id, opts)
       return nil
     end
 
-    # 
+    #
     # Download Document
-    # @param id 
+    # @param id
     # @param [Hash] opts the optional parameters
-    # @option opts [String] :last_modified 
+    # @option opts [String] :last_modified
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def system_documents_id_download_get_with_http_info(id, opts = {})
       if @api_client.config.debugging
@@ -276,9 +276,9 @@ module Connectwise
       return data, status_code, headers
     end
 
-    # 
+    #
     # Get Document Info By Id
-    # @param id 
+    # @param id
     # @param [Hash] opts the optional parameters
     # @return [DocumentInfo]
     def system_documents_id_get(id, opts = {})
@@ -286,9 +286,9 @@ module Connectwise
       return data
     end
 
-    # 
+    #
     # Get Document Info By Id
-    # @param id 
+    # @param id
     # @param [Hash] opts the optional parameters
     # @return [Array<(DocumentInfo, Fixnum, Hash)>] DocumentInfo data, response status code and response headers
     def system_documents_id_get_with_http_info(id, opts = {})
@@ -333,36 +333,36 @@ module Connectwise
       return data, status_code, headers
     end
 
-    # 
+    #
     # Update Document By Id
-    # @param id 
+    # @param id
     # @param record_id Entity id
     # @param record_type Entity type
     # @param title Document title
-    # @param url Document url
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :url Document url
     # @option opts [File] :file File to upload
     # @option opts [BOOLEAN] :private_flag Indicates if document is private
     # @option opts [BOOLEAN] :read_only_flag Indicates if document is readonly
     # @return [DocumentInfo]
-    def system_documents_id_post(id, record_id, record_type, title, url, opts = {})
-      data, _status_code, _headers = system_documents_id_post_with_http_info(id, record_id, record_type, title, url, opts)
+    def system_documents_id_post(id, record_id, record_type, title, opts = {})
+      data, _status_code, _headers = system_documents_id_post_with_http_info(id, record_id, record_type, title, opts)
       return data
     end
 
-    # 
+    #
     # Update Document By Id
-    # @param id 
+    # @param id
     # @param record_id Entity id
     # @param record_type Entity type
     # @param title Document title
-    # @param url Document url
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :url Document url
     # @option opts [File] :file File to upload
     # @option opts [BOOLEAN] :private_flag Indicates if document is private
     # @option opts [BOOLEAN] :read_only_flag Indicates if document is readonly
     # @return [Array<(DocumentInfo, Fixnum, Hash)>] DocumentInfo data, response status code and response headers
-    def system_documents_id_post_with_http_info(id, record_id, record_type, title, url, opts = {})
+    def system_documents_id_post_with_http_info(id, record_id, record_type, title, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: DocumentsApi.system_documents_id_post ..."
       end
@@ -382,9 +382,9 @@ module Connectwise
         fail ArgumentError, 'invalid value for "title" when calling DocumentsApi.system_documents_id_post, the character length must be smaller than or equal to 100.'
       end
 
-      # verify the required parameter 'url' is set
-      fail ArgumentError, "Missing the required parameter 'url' when calling DocumentsApi.system_documents_id_post" if url.nil?
-      if url.to_s.length > 500
+      # verify the required parameter 'url' or 'file' is set
+      fail ArgumentError, "Missing the required options 'url' or 'file' when calling DocumentsApi.system_documents_id_post" if opts[:url].nil? && opts[:file].nil?
+      if opts[:url] && opts[:url].to_s.length > 500
         fail ArgumentError, 'invalid value for "url" when calling DocumentsApi.system_documents_id_post, the character length must be smaller than or equal to 500.'
       end
 
@@ -410,7 +410,7 @@ module Connectwise
       form_params["recordId"] = record_id
       form_params["recordType"] = record_type
       form_params["title"] = title
-      form_params["url"] = url
+      form_params["url"] = opts[:url] unless opts[:url].nil?
       form_params["file"] = opts[:'file'] if !opts[:'file'].nil?
       form_params["privateFlag"] = opts[:'private_flag'] if !opts[:'private_flag'].nil?
       form_params["readOnlyFlag"] = opts[:'read_only_flag'] if !opts[:'read_only_flag'].nil?
@@ -431,34 +431,34 @@ module Connectwise
       return data, status_code, headers
     end
 
-    # 
+    #
     # Insert Document
     # @param record_id Entity id
     # @param record_type Entity type
     # @param title Document title
-    # @param url Document url
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :url Document url
     # @option opts [File] :file File to upload
     # @option opts [BOOLEAN] :private_flag Indicates if document is private
     # @option opts [BOOLEAN] :read_only_flag Indicates if document is readonly
     # @return [DocumentInfo]
-    def system_documents_post(record_id, record_type, title, url, opts = {})
-      data, _status_code, _headers = system_documents_post_with_http_info(record_id, record_type, title, url, opts)
+    def system_documents_post(record_id, record_type, title, opts = {})
+      data, _status_code, _headers = system_documents_post_with_http_info(record_id, record_type, title, opts)
       return data
     end
 
-    # 
+    #
     # Insert Document
     # @param record_id Entity id
     # @param record_type Entity type
     # @param title Document title
-    # @param url Document url
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :url Document url
     # @option opts [File] :file File to upload
     # @option opts [BOOLEAN] :private_flag Indicates if document is private
     # @option opts [BOOLEAN] :read_only_flag Indicates if document is readonly
     # @return [Array<(DocumentInfo, Fixnum, Hash)>] DocumentInfo data, response status code and response headers
-    def system_documents_post_with_http_info(record_id, record_type, title, url, opts = {})
+    def system_documents_post_with_http_info(record_id, record_type, title, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: DocumentsApi.system_documents_post ..."
       end
@@ -476,10 +476,10 @@ module Connectwise
         fail ArgumentError, 'invalid value for "title" when calling DocumentsApi.system_documents_post, the character length must be smaller than or equal to 100.'
       end
 
-      # verify the required parameter 'url' is set
-      fail ArgumentError, "Missing the required parameter 'url' when calling DocumentsApi.system_documents_post" if url.nil?
-      if url.to_s.length > 500
-        fail ArgumentError, 'invalid value for "url" when calling DocumentsApi.system_documents_post, the character length must be smaller than or equal to 500.'
+      # verify the required parameter 'url' or 'file' is set
+      fail ArgumentError, "Missing the required options 'url' or 'file' when calling DocumentsApi.system_documents_id_post" if opts[:url].nil? && opts[:file].nil?
+      if opts[:url] && opts[:url].to_s.length > 500
+        fail ArgumentError, 'invalid value for "url" when calling DocumentsApi.system_documents_id_post, the character length must be smaller than or equal to 500.'
       end
 
       # resource path
@@ -504,7 +504,7 @@ module Connectwise
       form_params["recordId"] = record_id
       form_params["recordType"] = record_type
       form_params["title"] = title
-      form_params["url"] = url
+      form_params["url"] = opts[:url] unless opts[:url].nil?
       form_params["file"] = opts[:'file'] if !opts[:'file'].nil?
       form_params["privateFlag"] = opts[:'private_flag'] if !opts[:'private_flag'].nil?
       form_params["readOnlyFlag"] = opts[:'read_only_flag'] if !opts[:'read_only_flag'].nil?
@@ -525,7 +525,7 @@ module Connectwise
       return data, status_code, headers
     end
 
-    # 
+    #
     # Get Upload Sample Page
     # @param [Hash] opts the optional parameters
     # @return [nil]
@@ -534,7 +534,7 @@ module Connectwise
       return nil
     end
 
-    # 
+    #
     # Get Upload Sample Page
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers


### PR DESCRIPTION
Change the url parameter of `system_documents_id_post` and `system_documents_post` to be optional.

## Description

When uploading a document the api will allow either the file param OR the url param, but neither is required if either is present. In fact, providing a url parameter while trying to upload a file causes the request to fail.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

