### PR TITLE
Add support for clientId header now required by Connectwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ ConnectWise.configure do |config|
   config.host = 'api-na.myconnectwise.net' # your connectwise url
   config.base_path = '/v4_6_release/apis/3.0' # Or alternative code base release
   config.scheme = 'https'
+  config.client_id = 'XXXX'
 end
 
 api_instance = ConnectWise::AccountingBatchesApi.new
@@ -2523,4 +2524,3 @@ Class | Method | HTTP request | Description
 ### BasicAuth
 
 - **Type**: HTTP basic authentication
-

--- a/lib/connectwise-ruby-sdk/api_client.rb
+++ b/lib/connectwise-ruby-sdk/api_client.rb
@@ -23,7 +23,8 @@ module ConnectWise
       @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
       @default_headers = {
         'Content-Type' => "application/json",
-        'User-Agent' => @user_agent
+        'User-Agent' => @user_agent,
+        'clientId'   => @config.client_id
       }
     end
 

--- a/lib/connectwise-ruby-sdk/configuration.rb
+++ b/lib/connectwise-ruby-sdk/configuration.rb
@@ -20,6 +20,12 @@ module ConnectWise
     #   config.api_key['api_key'] = 'xxx'
     attr_accessor :api_key
 
+    # Defines the clientId header to send with requests
+    #
+    # @return [String]
+    attr_accessor :client_id
+
+
     # Defines API key prefixes used with API Key authentications.
     #
     # @return [Hash] key: parameter name, value: API key prefix


### PR DESCRIPTION
Fixes #7

## Description
Add support for `client_id` configuration option, sending it as the `clientId` for all requests.

## Related Issue
#7

## Motivation and Context
Required by Connectwise beginning 6/3/2019

## How Has This Been Tested?
Nope! Current test configuration is broken on ruby 2.5
